### PR TITLE
allow webhook emitters to delay to prevent rate limiting

### DIFF
--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -123,6 +123,10 @@ def test_webhook_delay_minutes(
         'method': 'GET',
     }
     wh = webhook.Webhook(config=config)
+    # On init, we load delay_minutes from config
+    assert wh.delay_minutes == 3
+    # delay_until is unset until emitting calling emit once
+    assert wh.delay_until is None
     wh.emit({
         'color': 'black',
         'gravity': 1,
@@ -139,8 +143,9 @@ def test_webhook_delay_minutes(
     })
     now = datetime.datetime.now(datetime.timezone.utc)
     assert wh.delay_minutes == 3
-    assert wh.delay_until is not None
-    assert wh.delay_until >= now
+    # delay_until should be set for about 3 minutes from now
+    assert wh.delay_until is not None and wh.delay_until >= now
+    # emitted twice, but the second returned before actually sending a request.
     assert mock_requests.mock_calls == [
         mock.call.get('GET'),
         mock.ANY,
@@ -149,14 +154,19 @@ def test_webhook_delay_minutes(
             json={'color': 'black', 'gravity': 1, 'temp': 32}, url='http://example.com')  # noqa
     ]
 
+    # move the clock forward by setting delay_until to the past, which should
+    # allow a request to process again
     wh.delay_until = now - datetime.timedelta(minutes=1)
     wh.emit({
         'color': 'black',
-        'gravity': 2,
-        'temp': 33,
+        'gravity': 3,
+        'temp': 34,
         'mac': '00:0a:95:9d:68:16',
         'timestamp': 155558899
     })
+    # delay_until is once again about 3 minutes in the future
+    assert wh.delay_until is not None and wh.delay_until >= now
+    # we now see the request that was made after the delay timeout
     assert mock_requests.mock_calls == [
         mock.call.get('GET'),
         mock.ANY,
@@ -166,5 +176,5 @@ def test_webhook_delay_minutes(
         mock.ANY,
         mock.call.get()(
             headers={'Content-Type': 'application/json'},
-            json={'color': 'black', 'gravity': 2, 'temp': 33}, url='http://example.com')  # noqa
+            json={'color': 'black', 'gravity': 3, 'temp': 34}, url='http://example.com')  # noqa
     ]

--- a/tilty/emitters/webhook.py
+++ b/tilty/emitters/webhook.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 """ Webhook emitter """
+import datetime
 import json
 import logging
-from typing import Callable, Dict
+from typing import Callable, Dict, Union
 
 import requests
 from jinja2 import Template
@@ -36,8 +37,13 @@ class Webhook:  # pylint: disable=too-few-public-methods
         self.method = METHODS.get(config['method'])
         if self.method is None:
             raise KeyError
+        delay_minutes = config.get('delay_minutes')
+        if delay_minutes:
+            delay_minutes = int(delay_minutes)
+        self.delay_minutes: Union[int, None] = delay_minutes
         self.headers: dict = json.loads(config['headers'])
         self.template: Template = Template(config['payload_template'])
+        self.delay_until: Union[datetime.datetime, None] = None
 
     def emit(self, tilt_data: dict) -> requests.Response:
         """ Initializer
@@ -45,6 +51,10 @@ class Webhook:  # pylint: disable=too-few-public-methods
         Args:
             tilt_data (dict): data returned from valid tilt device scan
         """
+
+        now = datetime.datetime.now(datetime.timezone.utc)
+        if self.delay_until and now < self.delay_until:
+            return
 
         payload: dict = json.loads(self.template.render(
             color=tilt_data['color'],
@@ -60,6 +70,10 @@ class Webhook:  # pylint: disable=too-few-public-methods
             self.url,
             payload,
         )
+
+        if self.delay_minutes:
+            self.delay_until = now + datetime.timedelta(
+                    minutes=self.delay_minutes)
 
         if self.headers and 'json' in self.headers.get('Content-Type', {}):
             LOGGER.debug('[webhook] sending as json')


### PR DESCRIPTION
I added a `delay_minutes` configuration key to the webhook emitter configuration so that I can let other emitters like influx run on on a quick sleep interval, while not getting rate limited by my webhook endpoint (brewfather). Should be backward compatible with current configs. Not sure if it's something you might be interested in, but feel free to merge if you do want it. Thanks!