### PR TITLE
store webhook delays per mac address (hopefully per tilt)

### DIFF
--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -123,29 +123,33 @@ def test_webhook_delay_minutes(
         'payload_template': '{"color": "{{ color }}", "gravity": {{ gravity }}, "temp": {{ temp }}}',  # noqa
         'method': 'GET',
     }
+    black_tilt_mac = '00:0a:95:9d:68:16'
+    blue_tilt_mac = '00:0a:95:9d:68:17'
     wh = webhook.Webhook(config=config)
     # On init, we load delay_minutes from config
     assert wh.delay_minutes == 3
     # delay_until is unset until emitting calling emit once
-    assert wh.delay_until is None
+    delay_until = wh.delay_until.get(black_tilt_mac)
+    assert delay_until is None
     wh.emit({
         'color': 'black',
         'gravity': 1,
         'temp': 32,
-        'mac': '00:0a:95:9d:68:16',
+        'mac': black_tilt_mac,
         'timestamp': 155558888
     })
     wh.emit({
         'color': 'black',
         'gravity': 2,
         'temp': 33,
-        'mac': '00:0a:95:9d:68:16',
+        'mac': black_tilt_mac,
         'timestamp': 155558899
     })
     now = datetime.datetime.now(datetime.timezone.utc)
     assert wh.delay_minutes == 3
     # delay_until should be set for about 3 minutes from now
-    assert wh.delay_until is not None and wh.delay_until >= now
+    delay_until = wh.delay_until.get(black_tilt_mac)
+    assert delay_until is not None and delay_until >= now
     # emitted twice, but the second returned before actually sending a request.
     assert mock_requests.mock_calls == [
         mock.call.get('GET'),
@@ -155,9 +159,33 @@ def test_webhook_delay_minutes(
             json={'color': 'black', 'gravity': 1, 'temp': 32}, url='http://example.com')  # noqa
     ]
 
+    # enxure that the blue tilt can send while the black one is waiting
+    delay_until = wh.delay_until.get(blue_tilt_mac)
+    assert delay_until is None
+    wh.emit({
+        'color': 'blue',
+        'gravity': 99,
+        'temp': 99,
+        'mac': blue_tilt_mac,
+        'timestamp': 155559999
+    })
+    delay_until = wh.delay_until.get(blue_tilt_mac)
+    assert delay_until is not None and delay_until >= now
+    assert mock_requests.mock_calls == [
+        mock.call.get('GET'),
+        mock.ANY,
+        mock.call.get()(
+            headers={'Content-Type': 'application/json'},
+            json={'color': 'black', 'gravity': 1, 'temp': 32}, url='http://example.com'),  # noqa
+        mock.ANY,
+        mock.call.get()(
+            headers={'Content-Type': 'application/json'},
+            json={'color': 'blue', 'gravity': 99, 'temp': 99}, url='http://example.com')  # noqa
+    ]
+
     # move the clock forward by setting delay_until to the past, which should
     # allow a request to process again
-    wh.delay_until = now - datetime.timedelta(minutes=1)
+    wh.delay_until[black_tilt_mac] = now - datetime.timedelta(minutes=1)
     wh.emit({
         'color': 'black',
         'gravity': 3,
@@ -166,7 +194,8 @@ def test_webhook_delay_minutes(
         'timestamp': 155558899
     })
     # delay_until is once again about 3 minutes in the future
-    assert wh.delay_until is not None and wh.delay_until >= now
+    delay_until = wh.delay_until.get(black_tilt_mac)
+    assert delay_until is not None and delay_until >= now
     # we now see the request that was made after the delay timeout
     assert mock_requests.mock_calls == [
         mock.call.get('GET'),
@@ -174,6 +203,10 @@ def test_webhook_delay_minutes(
         mock.call.get()(
             headers={'Content-Type': 'application/json'},
             json={'color': 'black', 'gravity': 1, 'temp': 32}, url='http://example.com'),  # noqa
+        mock.ANY,
+        mock.call.get()(
+            headers={'Content-Type': 'application/json'},
+            json={'color': 'blue', 'gravity': 99, 'temp': 99}, url='http://example.com'),  # noqa
         mock.ANY,
         mock.call.get()(
             headers={'Content-Type': 'application/json'},

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -128,7 +128,6 @@ def test_webhook_delay_minutes(
         'method': 'GET',
     }
 
-    black_tilt_uuid = 'a495bb30c5b14b44b5121370f02d74de'
     blue_tilt_uuid = 'a495bb60c5b14b44b5121370f02d74de'
 
     wh = webhook.Webhook(config=config)

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -141,7 +141,7 @@ def test_webhook_delay_minutes(
         'mac': '00:0a:95:9d:68:16',
         'temp': 32,
         'timestamp': 155558888,
-        'uuid': black_tilt_uuid
+        'uuid': 'a495bb30c5b14b44b5121370f02d74de',
     })
     wh.emit({
         'color': 'black',

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -128,7 +128,6 @@ def test_webhook_delay_minutes(
         'method': 'GET',
     }
 
-    blue_tilt_uuid = 'a495bb60c5b14b44b5121370f02d74de'
 
     wh = webhook.Webhook(config=config)
     # On init, we load delay_minutes from config

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -150,7 +150,7 @@ def test_webhook_delay_minutes(
         'mac': '00:0a:95:9d:68:16',
         'temp': 33,
         'timestamp': 155558899,
-        'uuid': black_tilt_uuid
+        'uuid': 'a495bb30c5b14b44b5121370f02d74de',
     })
     now = datetime.datetime.now(datetime.timezone.utc)
     assert wh.delay_minutes == 3

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -134,7 +134,7 @@ def test_webhook_delay_minutes(
     # On init, we load delay_minutes from config
     assert wh.delay_minutes == 3
     # delay_until is unset until emitting calling emit once
-    delay_until = wh.delay_until.get(black_tilt_uuid)
+    delay_until = wh.delay_until.get('black')
     assert delay_until is None
     wh.emit({
         'color': 'black',

--- a/tilty/cli.py
+++ b/tilty/cli.py
@@ -47,9 +47,10 @@ def scan_and_emit(device: tilt_device.TiltDevice, emitters: List[dict]):
     LOGGER.debug('Starting device scan')
     tilt_data = device.scan_for_tilt_data()
     if tilt_data:
-        LOGGER.debug('tilt data retrieved')
-        LOGGER.info(tilt_data)
-        emit(emitters=emitters, tilt_data=tilt_data)
+        for event in tilt_data:
+            LOGGER.debug('tilt data retrieved')
+            LOGGER.info(event)
+            emit(emitters=emitters, tilt_data=event)
     else:
         LOGGER.debug('No tilt data')
 

--- a/tilty/emitters/webhook.py
+++ b/tilty/emitters/webhook.py
@@ -52,9 +52,9 @@ class Webhook:  # pylint: disable=too-few-public-methods
             tilt_data (dict): data returned from valid tilt device scan
         """
 
-        tilt_mac = str(tilt_data['mac'])
+        tilt_uuid = str(tilt_data['uuid'])
         now = datetime.datetime.now(datetime.timezone.utc)
-        delay_until = self.delay_until.get(tilt_mac)
+        delay_until = self.delay_until.get(tilt_uuid)
         if delay_until and now < delay_until:
             return None
 
@@ -74,7 +74,7 @@ class Webhook:  # pylint: disable=too-few-public-methods
         )
 
         if self.delay_minutes:
-            self.delay_until[tilt_mac] = now + datetime.timedelta(
+            self.delay_until[tilt_uuid] = now + datetime.timedelta(
                     minutes=self.delay_minutes)
 
         if self.headers and 'json' in self.headers.get('Content-Type', {}):

--- a/tilty/emitters/webhook.py
+++ b/tilty/emitters/webhook.py
@@ -55,7 +55,7 @@ class Webhook:  # pylint: disable=too-few-public-methods
             tilt_data (dict): data returned from valid tilt device scan
         """
 
-        tilt_uuid = str(tilt_data['uuid'])
+        delay_until_identifier = str(tilt_data[self.delay_until_identifier])
         now = datetime.datetime.now(datetime.timezone.utc)
         delay_until = self.delay_until.get(delay_until_identifier)
         if delay_until and now < delay_until:

--- a/tilty/emitters/webhook.py
+++ b/tilty/emitters/webhook.py
@@ -57,7 +57,7 @@ class Webhook:  # pylint: disable=too-few-public-methods
 
         tilt_uuid = str(tilt_data['uuid'])
         now = datetime.datetime.now(datetime.timezone.utc)
-        delay_until = self.delay_until.get(tilt_uuid)
+        delay_until = self.delay_until.get(delay_until_identifier)
         if delay_until and now < delay_until:
             return None
 

--- a/tilty/emitters/webhook.py
+++ b/tilty/emitters/webhook.py
@@ -43,7 +43,10 @@ class Webhook:  # pylint: disable=too-few-public-methods
         self.delay_minutes: Union[int, None] = delay_minutes
         self.headers: dict = json.loads(config['headers'])
         self.template: Template = Template(config['payload_template'])
-        self.delay_until: Dict[str, datetime.datetime] = dict()
+        self.delay_until_identifier = config.get(
+            'delay_until_identifier',
+            'color'
+        )
 
     def emit(self, tilt_data: dict) -> None:
         """ Initializer

--- a/tilty/emitters/webhook.py
+++ b/tilty/emitters/webhook.py
@@ -79,7 +79,6 @@ class Webhook:  # pylint: disable=too-few-public-methods
         if self.delay_minutes:
             timedelta = datetime.timedelta(minutes=self.delay_minutes)
             self.delay_until[delay_until_identifier] = now + timedelta
-                    minutes=self.delay_minutes)
 
         if self.headers and 'json' in self.headers.get('Content-Type', {}):
             LOGGER.debug('[webhook] sending as json')

--- a/tilty/emitters/webhook.py
+++ b/tilty/emitters/webhook.py
@@ -77,7 +77,8 @@ class Webhook:  # pylint: disable=too-few-public-methods
         )
 
         if self.delay_minutes:
-            self.delay_until[tilt_uuid] = now + datetime.timedelta(
+            timedelta = datetime.timedelta(minutes=self.delay_minutes)
+            self.delay_until[delay_until_identifier] = now + timedelta
                     minutes=self.delay_minutes)
 
         if self.headers and 'json' in self.headers.get('Content-Type', {}):

--- a/tilty/tilt_device.py
+++ b/tilty/tilt_device.py
@@ -38,24 +38,29 @@ class TiltDevice:  # pylint: disable=too-few-public-methods
         LOGGER.debug('Stopping device socket')
         blescan.hci_disable_le_scan(self.sock)
 
-    def scan_for_tilt_data(self) -> dict:
+    def scan_for_tilt_data(self) -> list:
         """ scan for tilt and return data if found """
 
-        data = {}
+        data = []
         LOGGER.debug('Looking for events')
         for beacon in blescan.get_events(self.sock):
-            if beacon['uuid'] in constants.TILT_DEVICES:
-                data = {
-                    'color': constants.TILT_DEVICES[beacon['uuid']],
+            uuid = beacon.get('uuid')
+            if uuid is None:
+                continue
+            color = constants.TILT_DEVICES.get(uuid)
+            if color:
+                data.append({
+                    'color': color,
                     'gravity': float(beacon['minor']/1000),
                     'temp': beacon['major'],
                     'mac': beacon['mac'],
                     'timestamp': datetime.now().isoformat(),
-                }
+                    'uuid': uuid
+                })
             else:
                 LOGGER.debug(
                     "Beacon UUID is not a tilt device: %s",
-                    beacon['uuid']
+                    uuid
                 )
 
         return data


### PR DESCRIPTION
Follow up to PR #25:

Didn't realize until a little later that I tied the delay for the webhooks together, creating a race condition between my tilts as to which would update when the delay interval finished. This PR modifies those delays to be tracked per mac address, which I'm thinking might be sufficient to tell them apart (but maybe color would work too?).